### PR TITLE
Update Allianz and Veeam scrapers to improve job data extraction and adapt to new API structure

### DIFF
--- a/sites/veeam.py
+++ b/sites/veeam.py
@@ -1,7 +1,6 @@
 from scraper.Scraper import Scraper
 from utils import publish_or_update, publish_logo, create_job, show_jobs, translate_city
 from getCounty import GetCounty
-from urllib.parse import quote
 
 _counties = GetCounty()
 url = "https://careers.veeam.com/search-jobs/results?ActiveFacetID=0&CurrentPage=1&RecordsPerPage=150&TotalContentResults=&Distance=50&RadiusUnitType=1&Keywords=&Location=Romania&Latitude=46.00000&Longitude=25.00000&ShowRadius=False&IsPagination=False&CustomFacetName=&FacetTerm=&FacetType=0&SearchResultsModuleName=Section+11+-+Search+Results+List&SearchFiltersModuleName=Section+11+-+Search+Filters&SortCriteria=0&SortDirection=0&SearchType=1&LocationType=2&LocationPath=798549&OrganizationIds=22681&PostalCode=&ResultsType=0&fc=&fl=&fcf=&afc=&afl=&afcf=&TotalContentPages=NaN"


### PR DESCRIPTION
This pull request updates job scraping functionality for two sites, Allianz and Veeam, by improving the way job data is fetched and processed. The changes include switching from HTML scraping to API-based data retrieval for Allianz, and minor adjustments to the Veeam scraper.

### Updates to Allianz job scraper (`sites/allianz.py`):

* **API Integration**: Replaced the previous HTML-based scraping method with an API-based approach using a JSON payload for fetching job data. This change improves reliability and simplifies data extraction.
* **Dynamic County Mapping**: Added functionality to dynamically map cities to counties using the `GetCounty` module and the `translate_city` utility.
* **Headers and Payload Setup**: Introduced custom headers and a JSON payload for API requests, ensuring compatibility with the Allianz API.

### Minor adjustments to Veeam job scraper (`sites/veeam.py`):

* **Code Cleanup**: Removed an unused import (`quote`) for cleaner and more maintainable code.