### PR TITLE
Refactor job data handling in Parexel, Strabag, and Tremend scrapers for improved clarity and error handling

### DIFF
--- a/sites/parexel.py
+++ b/sites/parexel.py
@@ -6,7 +6,7 @@ _counties = GetCounty()
 url = "https://jobs.parexel.com/en/search-jobs/results?ActiveFacetID=0&CurrentPage=1&RecordsPerPage=100&Distance=50&RadiusUnitType=0&Location=Romania&Latitude=46.00000&Longitude=25.00000&ShowRadius=False&IsPagination=False&FacetType=0&SearchResultsModuleName=Search+Results&SearchFiltersModuleName=Search+Filters&SortCriteria=0&SortDirection=0&SearchType=1&LocationType=2&LocationPath=798549&OrganizationIds=877&ResultsType=0"
 
 company = {"company": "Parexel"}
-finalJobs = list()
+finalJobs = []
 
 scraper = Scraper()
 scraper.set_headers({

--- a/sites/strabag.py
+++ b/sites/strabag.py
@@ -1,8 +1,6 @@
 from scraper.Scraper import Scraper
-from utils import publish_or_update, publish_logo, create_job, show_jobs, translate_city
-from getCounty import GetCounty
+from utils import publish_or_update, publish_logo, create_job, show_jobs
 
-_counties = GetCounty()
 def remove_words(text, words):
     for word in words:
         text = text.replace(word, "")
@@ -12,7 +10,7 @@ def remove_words(text, words):
 url = "https://jobboerse.strabag.at/inc/jobsuche_2025_v1.php"
 
 company = "Strabag"
-jobs = list()
+jobs = []
 
 data = {
     "MIME Type": "application/x-www-form-urlencoded; charset=UTF-8",
@@ -31,23 +29,28 @@ while True:
 
     jobs_containers = scraper.find_all("div", class_="search-entry__container")
 
-    if len(jobs_containers) == 0:
+    no_jobs = scraper.find("div", class_="no-result__actions")
+    if no_jobs:
         break
+    
 
     for job_container in jobs_containers:
-
-        jobs.append(
-            create_job(
-                job_title=job_container.find(
-                    "h4", class_="search-entry__headline")
-                .text.strip(),
-                job_link=job_container.find("a")["href"],
-                country="Romania",
-                company=company,
+        try:
+            jobs.append(
+                create_job(
+                    job_title=job_container.find(
+                        "h4", class_="search-entry__headline")
+                    .text.strip(),
+                    job_link=job_container.find("a")["href"],
+                    country="Romania",
+                    company=company,
+                )
             )
-        )
+        except Exception:
+            continue
 
     data["morejobs"] += 1
+
 
 publish_or_update(jobs)
 

--- a/sites/tremend.py
+++ b/sites/tremend.py
@@ -1,5 +1,5 @@
 from scraper.Scraper import Scraper
-from utils import publish_or_update, publish_logo, show_jobs, get_jobtype
+from utils import publish_or_update, publish_logo, show_jobs
 
 url = "https://tremend.com/careers/"
 company = "tremend"
@@ -8,29 +8,25 @@ scraper = Scraper()
 scraper.get_from_url(url, "HTML")
 
 final_jobs = []
-job_elements = scraper.find("div", id="jobs").find_all("div", class_="career-wrapper")
+job_elements = scraper.find_all(
+    "article", class_="career__job-card")
+
+print(f"Found {len(job_elements)} jobs on {company} careers page.")
 
 for job in job_elements:
     job_title = job.find("h3").text.strip()
-    job_link = "https://tremend.com/careers/" + job.find("a")["href"].strip("/")
-    remote = get_jobtype(job.find("p", id="location-word").text.strip())
+    job_link =  job.find("a")["href"]
 
-    if (
-        "Bucharest" in job.find("p", id="location-word").text
-        or "Romania" in job.find("p", id="location-word").text
-    ):
-
-        final_jobs.append(
-            {
-                "job_title": job_title,
-                "job_link": job_link,
-                "country": "Romania",
-                "company": company,
-                "remote": remote,
-                "city": "Bucuresti",
-                "county": "Bucuresti",
-            }
-        )
+    final_jobs.append(
+        {
+            "job_title": job_title,
+            "job_link": job_link,
+            "country": "Romania",
+            "company": company,
+            "city": "Bucuresti",
+            "county": "Bucuresti",
+        }
+    )
 
 publish_or_update(final_jobs)
 


### PR DESCRIPTION
This pull request includes updates to three job scraping scripts (`parexel.py`, `strabag.py`, and `tremend.py`) to improve code readability, simplify logic, and enhance functionality. The changes primarily involve refactoring for consistency, removing unused imports, updating job extraction logic, and adding error handling.

### Refactoring and Code Simplification:

- **`sites/parexel.py`:** Replaced `list()` with `[]` for defining the `finalJobs` variable to improve readability and align with Python best practices.
- **`sites/strabag.py`:** Replaced `list()` with `[]` for defining the `jobs` variable.

### Removal of Unused Code:

- **`sites/strabag.py`:** Removed the `_counties` variable and its associated import (`GetCounty`) as it was unused in the script.
- **`sites/tremend.py`:** Removed the `get_jobtype` import as the `remote` field and its logic were eliminated from job extraction. [[1]](diffhunk://#diff-10c70ebacd40a378aad6cd0dcd3961e6a04bc84fcff3c78be70a8212765b6ae9L2-R2) [[2]](diffhunk://#diff-10c70ebacd40a378aad6cd0dcd3961e6a04bc84fcff3c78be70a8212765b6ae9L11-L29)

### Enhanced Job Extraction Logic:

- **`sites/strabag.py`:** Updated the job scraping logic to handle cases where no jobs are found (`no_jobs` check) and added error handling (`try-except`) to skip problematic job entries without breaking the script. [[1]](diffhunk://#diff-049f6f12875a62a3873cd71b77f348a3ac59833cd39beafb2f111234fc65283cL34-R38) [[2]](diffhunk://#diff-049f6f12875a62a3873cd71b77f348a3ac59833cd39beafb2f111234fc65283cR49-R54)
- **`sites/tremend.py`:** Modified the job extraction process to use `find_all` directly on job cards, removed unnecessary concatenation for job links, and simplified city and county assignment. Added a debug print statement to log the number of jobs found.