### PR TITLE
Remove unused imports and simplify city and county assignment in Zentiva 

### DIFF
--- a/sites/zentiva.py
+++ b/sites/zentiva.py
@@ -1,10 +1,7 @@
 from scraper.Scraper import Scraper
-from utils import translate_city, publish_or_update, publish_logo, show_jobs
-from getCounty import GetCounty
+from utils import publish_or_update, publish_logo, show_jobs
 from math import ceil
 import json
-
-_counties = GetCounty()
 
 apiUrl = "https://zentiva.wd3.myworkdayjobs.com/wday/cxs/zentiva/Zentiva/jobs"
 scraper = Scraper()
@@ -38,11 +35,6 @@ for num in range(iteration):
         job_link = "https://zentiva.wd3.myworkdayjobs.com/en-US/Zentiva" + job.get(
             "externalPath"
         )
-        city = translate_city(
-            job.get("bulletFields")[1].split("/")[1].split(";")[0].strip()
-        )
-
-        county = _counties.get_county(city)
 
         finaljobs.append(
             {
@@ -50,8 +42,8 @@ for num in range(iteration):
                 "job_link": job_link,
                 "company": company.get("company"),
                 "country": "Romania",
-                "city": city,
-                "county": county,
+                "city": "Bucuresti",
+                "county": "Bucuresti",
             }
         )
 


### PR DESCRIPTION
This pull request makes a small update to the `sites/zentiva.py` scraper by simplifying how city and county information is assigned for jobs. Instead of dynamically extracting and translating the city and county, both are now hardcoded as "Bucuresti".

Key changes:

- Removed the use of `translate_city` and `GetCounty`, along with their related imports and logic. [[1]](diffhunk://#diff-11644ca96fabb255017071e01fffe3152fce2996cbe706f046ef5ad230c7efb2L2-L8) [[2]](diffhunk://#diff-11644ca96fabb255017071e01fffe3152fce2996cbe706f046ef5ad230c7efb2L41-R46)
- The `city` and `county` fields for each job are now set directly to "Bucuresti" instead of being parsed from job data.