### PR TITLE
Add timeout parameter to logo publishing request 

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -58,6 +58,7 @@ def publish_logo(company, logo_url):
         "https://api.peviitor.ro/v3/logo/add/",
         headers={"Content-Type": content_type},
         json=[{"id": company, "logo": logo_url}],
+        timeout=10,
     )
 
 


### PR DESCRIPTION
This pull request introduces a minor update to the `publish_logo` function in `utils.py`. The change adds a timeout to the HTTP request to prevent it from hanging indefinitely.

* Added a `timeout=10` parameter to the HTTP POST request in `publish_logo` to improve reliability and avoid potential hangs.