### PR TITLE
Add error handling to logo publishing function for improved reliability

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -54,12 +54,15 @@ def publish_or_update(data):
 
 def publish_logo(company, logo_url):
     content_type = "application/json"
-    requests.post(
-        "https://api.peviitor.ro/v3/logo/add/",
-        headers={"Content-Type": content_type},
-        json=[{"id": company, "logo": logo_url}],
-        timeout=10,
-    )
+    try:
+        requests.post(
+            "https://api.peviitor.ro/v3/logo/add/",
+            headers={"Content-Type": content_type},
+            json=[{"id": company, "logo": logo_url}],
+            timeout=10,
+        )
+    except Exception as e:
+        print(f"Failed to publish logo for {company}. Error: {e}")
 
 
 def show_jobs(data):


### PR DESCRIPTION
This pull request improves the robustness of the `publish_logo` function in `utils.py` by adding error handling for network or API call failures.

Error handling improvements:

* Added a `try-except` block around the `requests.post` call in `publish_logo` to catch and print exceptions if the logo publishing fails, making the function more resilient to errors.