### PR TITLE
Fixed Cargill scraper

### DIFF
--- a/sites/cargill.py
+++ b/sites/cargill.py
@@ -5,7 +5,7 @@ from getCounty import GetCounty, remove_diacritics
 _counties = GetCounty()
 def get_aditional_city(url):
     scraper = Scraper()
-    scraper.get_from_url(url)
+    scraper.get_from_url(url, verify=False)
 
     locations = scraper.find("span", {"class": "job-location"}).text.split("|")
 

--- a/sites/cargill.py
+++ b/sites/cargill.py
@@ -61,7 +61,6 @@ for job in jobs:
             "job_title": job_title,
             "job_link": job_link,
             "company": company.get("company"),
-            "country": "Romania",
             "city": city,
             "county": county,
         }


### PR DESCRIPTION
This pull request makes a minor change to how the scraper fetches data from URLs in `sites/cargill.py`. The change disables SSL certificate verification when making requests, which may help avoid errors with sites that have certificate issues.

* Changed the call to `scraper.get_from_url` to pass `verify=False`, disabling SSL certificate verification.